### PR TITLE
Don't crash if dependencies aren't installed.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,30 +1,50 @@
-require 'nokogiri'
-require 'rack/pygmoku'
-require 'rubypython'
+begin
+  # Table of contents support
+  require 'maruku'
+  require 'nokogiri'
 
-# Default python (2.7) seems to have issues on Heroku:
-# https://github.com/tmm1/pygments.rb/issues/10
-RubyPython.configure :python_exe => 'python2.6'
+  # Maruku gives us auto-ids w/ H2 elements (for use by TOC generation)
+  Tilt.prefer Tilt::MarukuTemplate
+rescue LoadError => e
+  $stderr.puts e.to_s
+end
 
-# Maruku gives us auto-ids w/ H2 elements (for use by TOC generation)
-Tilt.prefer Tilt::MarukuTemplate
+begin
+  # Syntax highlighting support
+  require 'rack/pygmoku'
+  require 'rubypython'
+
+  # Default python (2.7) seems to have issues on Heroku:
+  # https://github.com/tmm1/pygments.rb/issues/10
+  RubyPython.configure :python_exe => 'python2.6'
+rescue LoadError => e
+  $stderr.puts e.to_s
+end
 
 module Nesta
   class App
 
     # Support pygments syntax highlighting w/ <pre><code lang="ruby"></code></pre> blocks
-    use Rack::Pygmoku, { :lexer_attr => 'lang' }
+    use Rack::Pygmoku, { :lexer_attr => 'lang' } if Rack.const_defined?(:Pygmoku)
 
     # Route to theme assets
     use Rack::Static, :urls => ["/clean", "/favicon.ico", "/apple-touch-icon.png", "/apple-touch-icon-precomposed.png"], :root => "themes/clean/public"
 
-    # Provide page TOC    
-    def toc(page, toc_template = :table_of_contents)
-      toc_headers = Nokogiri::HTML(page.body).css('h2').inject({}) do |mappings, header_node|
-        mappings[header_node.attr('id')] = header_node.content
-        mappings
+    helpers do
+      def can_generate_toc?
+        [:Maruku, :Nokogiri].all? { |cls| Object.const_defined?(cls) }
       end
-      haml(toc_template, :layout => false, :locals => { :toc_headers => toc_headers })
+
+      # Provide page TOC    
+      def toc(page, toc_template = :table_of_contents)
+        return nil unless can_generate_toc?
+        headings = Nokogiri::HTML(page.body(self)).css('h2')
+        toc_headers = headings.inject({}) do |mappings, header_node|
+          mappings[header_node.attr('id')] = header_node.content
+          mappings
+        end
+        haml(toc_template, :layout => false, :locals => { :toc_headers => toc_headers })
+      end
     end
   end
 end


### PR DESCRIPTION
It was failing (as reported in #1) on my freshly made test site because some of the gems that `app.rb` depends on weren't in my `Gemfile`. This patch logs an error message on `LoadError` to give the user a better idea of what's wrong.

Pages render too, if fairly slowly (though there's a styling problem with very large article headings on the home page; there should probably be a separate issue for that).
